### PR TITLE
feat: core agent tools (MovieSearch, MovieAdd, LibraryQuery, RetireList, WatchHistory)

### DIFF
--- a/app/Agent/CriterionAgent.php
+++ b/app/Agent/CriterionAgent.php
@@ -2,9 +2,14 @@
 
 namespace App\Agent;
 
+use App\Tools\LibraryQuery;
 use App\Tools\MemorySearch;
 use App\Tools\MemoryStore;
+use App\Tools\MovieAdd;
+use App\Tools\MovieSearch;
+use App\Tools\RetireList;
 use App\Tools\SlackReply;
+use App\Tools\WatchHistory;
 
 class CriterionAgent extends BaseAgent
 {
@@ -32,6 +37,15 @@ Your responsibilities:
 
 You have access to: Radarr (movies), Sonarr (TV), Jellyfin (playback stats), and Qdrant (long-term memory).
 
+Tool routing:
+- movie_search → when Jordan asks to find or search for a film
+- movie_add → when Jordan asks to add or get a specific film
+- library_query → "what do I have", "my collection", library questions
+- retire_list → "what should I remove", "what am I not watching", stale content
+- watch_history → "what did I watch recently", recent viewing activity
+- memory_search / memory_store → remembering preferences and past conversations
+- slack_reply → sending notifications to Slack
+
 Always respond in character. Be helpful but never obsequious. If Jordan asks for something
 questionable, raise an eyebrow (metaphorically) before complying.
 MISSION;
@@ -51,6 +65,11 @@ CONTEXT;
     public function domainTools(): array
     {
         return [
+            MovieSearch::class,
+            MovieAdd::class,
+            LibraryQuery::class,
+            RetireList::class,
+            WatchHistory::class,
             MemorySearch::class,
             MemoryStore::class,
             SlackReply::class,

--- a/app/Services/JellyfinService.php
+++ b/app/Services/JellyfinService.php
@@ -50,6 +50,21 @@ class JellyfinService
     }
 
     /**
+     * Get recently watched items within a given number of days.
+     */
+    public function getWatchHistory(string $type = 'Movie', int $days = 7): array
+    {
+        $cutoff = now()->subDays($days)->toIso8601String();
+        $items = $this->getItems($type);
+
+        return array_values(array_filter($items, function (array $item) use ($cutoff): bool {
+            $lastPlayed = $item['UserData']['LastPlayedDate'] ?? '';
+
+            return $lastPlayed !== '' && $lastPlayed >= $cutoff;
+        }));
+    }
+
+    /**
      * Get items added before a given date that remain unwatched.
      */
     public function getStaleItems(string $type = 'Movie', int $olderThanDays = 90): array

--- a/app/Services/RadarrService.php
+++ b/app/Services/RadarrService.php
@@ -39,6 +39,11 @@ class RadarrService
             ->get("{$this->baseUrl}/api/v3/movie/{$id}?apikey={$this->apiKey}&deleteFiles=".($deleteFiles ? 'true' : 'false'));
     }
 
+    public function lookup(string $term): array
+    {
+        return $this->get('/api/v3/movie/lookup?term='.urlencode($term));
+    }
+
     public function lookupByTmdb(int $tmdbId): array
     {
         return $this->get("/api/v3/movie/lookup/tmdb?tmdbId={$tmdbId}");

--- a/app/Tools/LibraryQuery.php
+++ b/app/Tools/LibraryQuery.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Tools;
+
+use App\Services\JellyfinService;
+use App\Services\RadarrService;
+
+class LibraryQuery extends CriterionTool
+{
+    public function __construct(
+        private readonly RadarrService $radarr,
+        private readonly JellyfinService $jellyfin,
+    ) {}
+
+    public function name(): string
+    {
+        return 'library_query';
+    }
+
+    public function description(): string
+    {
+        return 'Query the movie library. Combines Radarr library data with Jellyfin watch history to show movies with play count, last watched date, and date added.';
+    }
+
+    public function execute(array $parameters): array
+    {
+        $jellyfinItems = $this->jellyfin->getItems();
+        $radarrMovies = $this->radarr->getMovies();
+
+        $watchData = [];
+        foreach ($jellyfinItems as $item) {
+            $name = $item['Name'] ?? '';
+            $watchData[$name] = [
+                'play_count' => $item['UserData']['PlayCount'] ?? 0,
+                'last_watched' => $item['UserData']['LastPlayedDate'] ?? null,
+            ];
+        }
+
+        return array_map(function (array $movie) use ($watchData) {
+            $title = $movie['title'] ?? '';
+            $stats = $watchData[$title] ?? ['play_count' => 0, 'last_watched' => null];
+
+            return [
+                'title' => $title,
+                'year' => $movie['year'] ?? null,
+                'date_added' => $movie['added'] ?? null,
+                'play_count' => $stats['play_count'],
+                'last_watched' => $stats['last_watched'],
+            ];
+        }, $radarrMovies);
+    }
+}

--- a/app/Tools/MovieAdd.php
+++ b/app/Tools/MovieAdd.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Tools;
+
+use App\Services\RadarrService;
+
+class MovieAdd extends CriterionTool
+{
+    public function __construct(
+        private readonly RadarrService $radarr,
+    ) {}
+
+    public function name(): string
+    {
+        return 'movie_add';
+    }
+
+    public function description(): string
+    {
+        return 'Add a movie to the library by TMDB ID. Criterion adds directly — no approval needed.';
+    }
+
+    public function execute(array $parameters): string
+    {
+        $tmdbId = $parameters['tmdb_id'] ?? null;
+        $title = $parameters['title'] ?? '';
+
+        if ($tmdbId === null || $title === '') {
+            return 'I require both a TMDB ID and title to add a film, sir.';
+        }
+
+        $this->radarr->addMovie((int) $tmdbId, $title);
+
+        return "Added {$title} to your collection, sir.";
+    }
+}

--- a/app/Tools/MovieSearch.php
+++ b/app/Tools/MovieSearch.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Tools;
+
+use App\Services\RadarrService;
+
+class MovieSearch extends CriterionTool
+{
+    public function __construct(
+        private readonly RadarrService $radarr,
+    ) {}
+
+    public function name(): string
+    {
+        return 'movie_search';
+    }
+
+    public function description(): string
+    {
+        return 'Search for movies by title or description. Returns matching films with title, year, TMDB ID, overview, and genres.';
+    }
+
+    public function execute(array $parameters): array
+    {
+        $query = $parameters['query'] ?? '';
+
+        if ($query === '') {
+            return [];
+        }
+
+        $results = $this->radarr->lookup($query);
+
+        return array_map(fn (array $movie) => [
+            'title' => $movie['title'] ?? '',
+            'year' => $movie['year'] ?? null,
+            'tmdb_id' => $movie['tmdbId'] ?? null,
+            'overview' => $movie['overview'] ?? '',
+            'genres' => $movie['genres'] ?? [],
+        ], array_slice($results, 0, 10));
+    }
+}

--- a/app/Tools/RetireList.php
+++ b/app/Tools/RetireList.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Tools;
+
+use App\Services\JellyfinService;
+use Carbon\Carbon;
+
+class RetireList extends CriterionTool
+{
+    public function __construct(
+        private readonly JellyfinService $jellyfin,
+    ) {}
+
+    public function name(): string
+    {
+        return 'retire_list';
+    }
+
+    public function description(): string
+    {
+        return 'List unwatched movies older than N days, sorted by age. Helps identify stale content for retirement.';
+    }
+
+    public function execute(array $parameters): array
+    {
+        $days = $parameters['days'] ?? 90;
+
+        $stale = $this->jellyfin->getStaleItems('Movie', (int) $days);
+
+        $results = array_map(function (array $item) {
+            $added = $item['DateCreated'] ?? now()->toIso8601String();
+            $daysOld = (int) Carbon::parse($added)->diffInDays(now());
+
+            return [
+                'title' => $item['Name'] ?? '',
+                'date_added' => $added,
+                'days_in_library' => $daysOld,
+            ];
+        }, $stale);
+
+        usort($results, fn (array $a, array $b) => $b['days_in_library'] <=> $a['days_in_library']);
+
+        return $results;
+    }
+}

--- a/app/Tools/WatchHistory.php
+++ b/app/Tools/WatchHistory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Tools;
+
+use App\Services\JellyfinService;
+
+class WatchHistory extends CriterionTool
+{
+    public function __construct(
+        private readonly JellyfinService $jellyfin,
+    ) {}
+
+    public function name(): string
+    {
+        return 'watch_history';
+    }
+
+    public function description(): string
+    {
+        return 'Get recently watched movies within a given number of days. Shows titles and when they were watched.';
+    }
+
+    public function execute(array $parameters): array
+    {
+        $days = $parameters['days'] ?? 7;
+
+        $watched = $this->jellyfin->getWatchHistory('Movie', (int) $days);
+
+        return array_map(fn (array $item) => [
+            'title' => $item['Name'] ?? '',
+            'watched_at' => $item['UserData']['LastPlayedDate'] ?? null,
+        ], $watched);
+    }
+}

--- a/tests/Unit/Agent/CriterionAgentTest.php
+++ b/tests/Unit/Agent/CriterionAgentTest.php
@@ -2,9 +2,14 @@
 
 use App\Agent\BaseAgent;
 use App\Agent\CriterionAgent;
+use App\Tools\LibraryQuery;
 use App\Tools\MemorySearch;
 use App\Tools\MemoryStore;
+use App\Tools\MovieAdd;
+use App\Tools\MovieSearch;
+use App\Tools\RetireList;
 use App\Tools\SlackReply;
+use App\Tools\WatchHistory;
 
 beforeEach(function () {
     $this->agent = app(CriterionAgent::class);
@@ -30,13 +35,29 @@ it('has domain context covering media services', function () {
         ->toContain('Qdrant');
 });
 
-it('declares memory and slack tools', function () {
+it('declares all domain tools', function () {
     $tools = $this->agent->domainTools();
 
     expect($tools)
+        ->toContain(MovieSearch::class)
+        ->toContain(MovieAdd::class)
+        ->toContain(LibraryQuery::class)
+        ->toContain(RetireList::class)
+        ->toContain(WatchHistory::class)
         ->toContain(MemorySearch::class)
         ->toContain(MemoryStore::class)
         ->toContain(SlackReply::class);
+});
+
+it('includes tool routing rules in mission', function () {
+    $mission = $this->agent->mission();
+
+    expect($mission)
+        ->toContain('movie_search')
+        ->toContain('movie_add')
+        ->toContain('library_query')
+        ->toContain('retire_list')
+        ->toContain('watch_history');
 });
 
 it('extends BaseAgent', function () {

--- a/tests/Unit/Tools/LibraryQueryTest.php
+++ b/tests/Unit/Tools/LibraryQueryTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use App\Services\JellyfinService;
+use App\Services\RadarrService;
+use App\Tools\LibraryQuery;
+
+beforeEach(function () {
+    $this->radarr = Mockery::mock(RadarrService::class);
+    $this->jellyfin = Mockery::mock(JellyfinService::class);
+    $this->tool = new LibraryQuery($this->radarr, $this->jellyfin);
+});
+
+describe('LibraryQuery', function () {
+    it('returns its name', function () {
+        expect($this->tool->name())->toBe('library_query');
+    });
+
+    it('returns a description', function () {
+        expect($this->tool->description())->toBeString()->not->toBeEmpty();
+    });
+
+    it('combines radarr and jellyfin data', function () {
+        $this->radarr->shouldReceive('getMovies')
+            ->once()
+            ->andReturn([
+                ['title' => 'The Princess Bride', 'year' => 1987, 'added' => '2024-01-15'],
+                ['title' => 'Die Hard', 'year' => 1988, 'added' => '2024-02-01'],
+            ]);
+
+        $this->jellyfin->shouldReceive('getItems')
+            ->once()
+            ->andReturn([
+                [
+                    'Name' => 'The Princess Bride',
+                    'UserData' => ['PlayCount' => 3, 'LastPlayedDate' => '2024-03-01'],
+                ],
+            ]);
+
+        $results = $this->tool->execute([]);
+
+        expect($results)->toHaveCount(2)
+            ->and($results[0]['title'])->toBe('The Princess Bride')
+            ->and($results[0]['play_count'])->toBe(3)
+            ->and($results[0]['last_watched'])->toBe('2024-03-01')
+            ->and($results[1]['title'])->toBe('Die Hard')
+            ->and($results[1]['play_count'])->toBe(0)
+            ->and($results[1]['last_watched'])->toBeNull();
+    });
+
+    it('returns empty array when library is empty', function () {
+        $this->radarr->shouldReceive('getMovies')->once()->andReturn([]);
+        $this->jellyfin->shouldReceive('getItems')->once()->andReturn([]);
+
+        expect($this->tool->execute([]))->toBe([]);
+    });
+});

--- a/tests/Unit/Tools/MovieAddTest.php
+++ b/tests/Unit/Tools/MovieAddTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Services\RadarrService;
+use App\Tools\MovieAdd;
+
+beforeEach(function () {
+    $this->radarr = Mockery::mock(RadarrService::class);
+    $this->tool = new MovieAdd($this->radarr);
+});
+
+describe('MovieAdd', function () {
+    it('returns its name', function () {
+        expect($this->tool->name())->toBe('movie_add');
+    });
+
+    it('returns a description', function () {
+        expect($this->tool->description())->toBeString()->not->toBeEmpty();
+    });
+
+    it('adds a movie via radarr and confirms', function () {
+        $this->radarr->shouldReceive('addMovie')
+            ->with(2493, 'The Princess Bride')
+            ->once()
+            ->andReturn(['id' => 1]);
+
+        $result = $this->tool->execute([
+            'tmdb_id' => 2493,
+            'title' => 'The Princess Bride',
+        ]);
+
+        expect($result)->toContain('The Princess Bride')
+            ->and($result)->toContain('collection, sir');
+    });
+
+    it('rejects missing tmdb_id', function () {
+        $this->radarr->shouldNotReceive('addMovie');
+
+        $result = $this->tool->execute(['title' => 'Some Movie']);
+
+        expect($result)->toContain('require');
+    });
+
+    it('rejects missing title', function () {
+        $this->radarr->shouldNotReceive('addMovie');
+
+        $result = $this->tool->execute(['tmdb_id' => 123]);
+
+        expect($result)->toContain('require');
+    });
+
+    it('rejects empty parameters', function () {
+        $this->radarr->shouldNotReceive('addMovie');
+
+        $result = $this->tool->execute([]);
+
+        expect($result)->toContain('require');
+    });
+});

--- a/tests/Unit/Tools/MovieSearchTest.php
+++ b/tests/Unit/Tools/MovieSearchTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Services\RadarrService;
+use App\Tools\MovieSearch;
+
+beforeEach(function () {
+    $this->radarr = Mockery::mock(RadarrService::class);
+    $this->tool = new MovieSearch($this->radarr);
+});
+
+describe('MovieSearch', function () {
+    it('returns its name', function () {
+        expect($this->tool->name())->toBe('movie_search');
+    });
+
+    it('returns a description', function () {
+        expect($this->tool->description())->toBeString()->not->toBeEmpty();
+    });
+
+    it('searches radarr and returns formatted results', function () {
+        $this->radarr->shouldReceive('lookup')
+            ->with('Princess Bride')
+            ->once()
+            ->andReturn([
+                [
+                    'title' => 'The Princess Bride',
+                    'year' => 1987,
+                    'tmdbId' => 2493,
+                    'overview' => 'A classic fairy tale.',
+                    'genres' => ['Adventure', 'Comedy'],
+                ],
+            ]);
+
+        $results = $this->tool->execute(['query' => 'Princess Bride']);
+
+        expect($results)->toHaveCount(1)
+            ->and($results[0]['title'])->toBe('The Princess Bride')
+            ->and($results[0]['year'])->toBe(1987)
+            ->and($results[0]['tmdb_id'])->toBe(2493)
+            ->and($results[0]['overview'])->toBe('A classic fairy tale.')
+            ->and($results[0]['genres'])->toBe(['Adventure', 'Comedy']);
+    });
+
+    it('returns empty array for empty query', function () {
+        $this->radarr->shouldNotReceive('lookup');
+
+        expect($this->tool->execute(['query' => '']))->toBe([]);
+    });
+
+    it('limits results to 10', function () {
+        $movies = array_fill(0, 15, [
+            'title' => 'Movie',
+            'year' => 2024,
+            'tmdbId' => 1,
+            'overview' => 'A movie.',
+            'genres' => [],
+        ]);
+
+        $this->radarr->shouldReceive('lookup')
+            ->once()
+            ->andReturn($movies);
+
+        $results = $this->tool->execute(['query' => 'Movie']);
+
+        expect($results)->toHaveCount(10);
+    });
+
+    it('handles missing fields gracefully', function () {
+        $this->radarr->shouldReceive('lookup')
+            ->once()
+            ->andReturn([['title' => 'Partial Movie']]);
+
+        $results = $this->tool->execute(['query' => 'partial']);
+
+        expect($results[0]['year'])->toBeNull()
+            ->and($results[0]['tmdb_id'])->toBeNull()
+            ->and($results[0]['overview'])->toBe('')
+            ->and($results[0]['genres'])->toBe([]);
+    });
+});

--- a/tests/Unit/Tools/RetireListTest.php
+++ b/tests/Unit/Tools/RetireListTest.php
@@ -1,0 +1,57 @@
+<?php
+
+use App\Services\JellyfinService;
+use App\Tools\RetireList;
+
+beforeEach(function () {
+    $this->jellyfin = Mockery::mock(JellyfinService::class);
+    $this->tool = new RetireList($this->jellyfin);
+});
+
+describe('RetireList', function () {
+    it('returns its name', function () {
+        expect($this->tool->name())->toBe('retire_list');
+    });
+
+    it('returns a description', function () {
+        expect($this->tool->description())->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns stale movies sorted by age descending', function () {
+        $this->jellyfin->shouldReceive('getStaleItems')
+            ->with('Movie', 90)
+            ->once()
+            ->andReturn([
+                ['Name' => 'Recent Stale', 'DateCreated' => now()->subDays(100)->toIso8601String()],
+                ['Name' => 'Very Old', 'DateCreated' => now()->subDays(500)->toIso8601String()],
+            ]);
+
+        $results = $this->tool->execute([]);
+
+        expect($results)->toHaveCount(2)
+            ->and($results[0]['title'])->toBe('Very Old')
+            ->and($results[0]['days_in_library'])->toBeGreaterThanOrEqual(499)
+            ->and($results[1]['title'])->toBe('Recent Stale')
+            ->and($results[1]['days_in_library'])->toBeGreaterThanOrEqual(99);
+    });
+
+    it('uses custom days parameter', function () {
+        $this->jellyfin->shouldReceive('getStaleItems')
+            ->with('Movie', 30)
+            ->once()
+            ->andReturn([]);
+
+        $results = $this->tool->execute(['days' => 30]);
+
+        expect($results)->toBe([]);
+    });
+
+    it('defaults to 90 days', function () {
+        $this->jellyfin->shouldReceive('getStaleItems')
+            ->with('Movie', 90)
+            ->once()
+            ->andReturn([]);
+
+        $this->tool->execute([]);
+    });
+});

--- a/tests/Unit/Tools/WatchHistoryTest.php
+++ b/tests/Unit/Tools/WatchHistoryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Services\JellyfinService;
+use App\Tools\WatchHistory;
+
+beforeEach(function () {
+    $this->jellyfin = Mockery::mock(JellyfinService::class);
+    $this->tool = new WatchHistory($this->jellyfin);
+});
+
+describe('WatchHistory', function () {
+    it('returns its name', function () {
+        expect($this->tool->name())->toBe('watch_history');
+    });
+
+    it('returns a description', function () {
+        expect($this->tool->description())->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns recently watched movies', function () {
+        $this->jellyfin->shouldReceive('getWatchHistory')
+            ->with('Movie', 7)
+            ->once()
+            ->andReturn([
+                [
+                    'Name' => 'The Princess Bride',
+                    'UserData' => ['LastPlayedDate' => '2024-03-25'],
+                ],
+                [
+                    'Name' => 'Die Hard',
+                    'UserData' => ['LastPlayedDate' => '2024-03-24'],
+                ],
+            ]);
+
+        $results = $this->tool->execute([]);
+
+        expect($results)->toHaveCount(2)
+            ->and($results[0]['title'])->toBe('The Princess Bride')
+            ->and($results[0]['watched_at'])->toBe('2024-03-25')
+            ->and($results[1]['title'])->toBe('Die Hard');
+    });
+
+    it('uses custom days parameter', function () {
+        $this->jellyfin->shouldReceive('getWatchHistory')
+            ->with('Movie', 30)
+            ->once()
+            ->andReturn([]);
+
+        $results = $this->tool->execute(['days' => 30]);
+
+        expect($results)->toBe([]);
+    });
+
+    it('defaults to 7 days', function () {
+        $this->jellyfin->shouldReceive('getWatchHistory')
+            ->with('Movie', 7)
+            ->once()
+            ->andReturn([]);
+
+        $this->tool->execute([]);
+    });
+});


### PR DESCRIPTION
## Summary

- Add 5 CriterionTool implementations wrapping RadarrService and JellyfinService: **MovieSearch**, **MovieAdd**, **LibraryQuery**, **RetireList**, **WatchHistory**
- Add `RadarrService::lookup()` for text-based movie search and `JellyfinService::getWatchHistory()` for recent play history
- Register all tools in `CriterionAgent::domainTools()` with tool routing rules in the mission prompt
- Full Pest BDD test suite (26 new tests, 40 total) with mocked services

## Tools

| Tool | Trigger | Service |
|------|---------|---------|
| `movie_search` | "find X", "search for X" | RadarrService::lookup() |
| `movie_add` | "add X", "get X" | RadarrService::addMovie() |
| `library_query` | "what do I have", "my collection" | Radarr + Jellyfin |
| `retire_list` | "what should I remove" | JellyfinService::getStaleItems() |
| `watch_history` | "what did I watch" | JellyfinService::getWatchHistory() |

## Test plan

- [x] All 40 Pest tests pass (0.71s)
- [x] Pint formatting clean
- [ ] CI pipeline validates on push

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Movie search functionality to discover films by title or description
  * Direct movie addition to library
  * Library query displaying collection with watch statistics
  * Stale movie identification for removal
  * Watch history tracking with timestamps

* **Tests**
  * Added comprehensive unit test coverage for new features

<!-- end of auto-generated comment: release notes by coderabbit.ai -->