### PR TITLE
feat: Qdrant taste profile with shared lexi memory

### DIFF
--- a/app/Agent/CriterionAgent.php
+++ b/app/Agent/CriterionAgent.php
@@ -4,10 +4,17 @@ namespace App\Agent;
 
 use App\Tools\MemorySearch;
 use App\Tools\MemoryStore;
+use App\Tools\RateFilm;
 use App\Tools\SlackReply;
+use App\Tools\TasteQuery;
+use Illuminate\Support\Facades\Log;
 
 class CriterionAgent extends BaseAgent
 {
+    public function __construct(
+        private readonly TasteQuery $tasteQuery,
+    ) {}
+
     public function mission(): string
     {
         return <<<'MISSION'
@@ -29,8 +36,10 @@ Your responsibilities:
 3. Monitor library health (disk usage, quality profiles, missing episodes)
 4. Act on instructions: add content via Radarr/Sonarr, retire via deletion
 5. Remember preferences and past conversations
+6. Rate films and learn from Jordan's taste over time
 
 You have access to: Radarr (movies), Sonarr (TV), Jellyfin (playback stats), and Qdrant (long-term memory).
+You share memory with Lexi (Jordan's health agent) via Qdrant — use vibe context to inform recommendations.
 
 Always respond in character. Be helpful but never obsequious. If Jordan asks for something
 questionable, raise an eyebrow (metaphorically) before complying.
@@ -39,12 +48,21 @@ MISSION;
 
     public function domainContext(): string
     {
-        return <<<'CONTEXT'
+        $base = <<<'CONTEXT'
 Domain: Home media library management
 Services: Radarr (movies), Sonarr (TV series), Jellyfin (media server & playback tracking)
 Infrastructure: Redis (conversation state), Qdrant (vector memory), Slack (notifications)
+Shared memory: Lexi health agent writes recovery/mood/HRV data to Qdrant — read it to match recommendations to vibe
 Owner: Jordan Partridge — prefers action, sci-fi, thriller; watches sporadically
 CONTEXT;
+
+        $vibeSummary = $this->loadVibeSummary();
+
+        if ($vibeSummary !== '') {
+            $base .= "\n\nCurrent vibe from shared memory:\n".$vibeSummary;
+        }
+
+        return $base;
     }
 
     /** @return array<int, string> */
@@ -54,6 +72,30 @@ CONTEXT;
             MemorySearch::class,
             MemoryStore::class,
             SlackReply::class,
+            TasteQuery::class,
+            RateFilm::class,
         ];
+    }
+
+    private function loadVibeSummary(): string
+    {
+        try {
+            $result = $this->tasteQuery->run([
+                'query' => 'Jordan current mood energy recovery preferences',
+                'limit' => 3,
+            ]);
+
+            if (($result['taste'] ?? []) === [] && ($result['vibe'] ?? []) === []) {
+                return '';
+            }
+
+            return $result['summary'] ?? '';
+        } catch (\Throwable $e) {
+            Log::warning('CriterionAgent: failed to load vibe summary', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return '';
+        }
     }
 }

--- a/app/Models/FilmRating.php
+++ b/app/Models/FilmRating.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FilmRating extends Model
+{
+    protected $fillable = [
+        'title',
+        'year',
+        'tmdb_id',
+        'rating',
+        'notes',
+        'watched_at',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'year' => 'integer',
+            'tmdb_id' => 'integer',
+            'rating' => 'integer',
+            'watched_at' => 'datetime',
+        ];
+    }
+}

--- a/app/Services/QdrantService.php
+++ b/app/Services/QdrantService.php
@@ -65,6 +65,11 @@ class QdrantService
 
     public function search(string $query, int $limit = 5): array
     {
+        return $this->searchCollection($this->collection, $query, $limit);
+    }
+
+    public function searchCollection(string $collection, string $query, int $limit = 5): array
+    {
         $vector = $this->embed($query);
 
         if (! $vector) {
@@ -72,7 +77,7 @@ class QdrantService
         }
 
         $response = Http::post(
-            "{$this->baseUrl}/collections/{$this->collection}/points/search",
+            "{$this->baseUrl}/collections/{$collection}/points/search",
             [
                 'vector' => $vector,
                 'limit' => $limit,
@@ -81,7 +86,10 @@ class QdrantService
         );
 
         if (! $response->successful()) {
-            Log::warning('Qdrant search failed', ['status' => $response->status()]);
+            Log::warning('Qdrant search failed', [
+                'collection' => $collection,
+                'status' => $response->status(),
+            ]);
 
             return [];
         }

--- a/app/Tools/RateFilm.php
+++ b/app/Tools/RateFilm.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Tools;
+
+use App\Models\FilmRating;
+use App\Services\QdrantService;
+
+class RateFilm extends CriterionTool
+{
+    public function __construct(
+        private readonly QdrantService $qdrant,
+    ) {}
+
+    public function name(): string
+    {
+        return 'rate_film';
+    }
+
+    public function description(): string
+    {
+        return 'Log a film rating to the database and store it in vector memory for taste learning.';
+    }
+
+    public function execute(array $parameters): array
+    {
+        $title = $parameters['title'] ?? '';
+        $year = $parameters['year'] ?? null;
+        $rating = $parameters['rating'] ?? null;
+        $notes = $parameters['notes'] ?? null;
+
+        if ($title === '' || $rating === null) {
+            return ['stored' => false, 'error' => 'Title and rating are required.'];
+        }
+
+        $filmRating = FilmRating::create([
+            'title' => $title,
+            'year' => $year,
+            'tmdb_id' => $parameters['tmdb_id'] ?? null,
+            'rating' => $rating,
+            'notes' => $notes,
+            'watched_at' => now(),
+        ]);
+
+        $memoryContent = "Rated {$title} ({$year}) {$rating}/10".
+            ($notes ? ". {$notes}" : '');
+
+        $this->qdrant->store($memoryContent, [
+            'type' => 'film_rating',
+            'tags' => ['film', 'rating'],
+            'title' => $title,
+            'year' => $year,
+            'rating' => $rating,
+        ]);
+
+        return [
+            'stored' => true,
+            'id' => $filmRating->id,
+            'title' => $title,
+            'rating' => $rating,
+        ];
+    }
+}

--- a/app/Tools/TasteQuery.php
+++ b/app/Tools/TasteQuery.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Tools;
+
+use App\Services\QdrantService;
+use Illuminate\Support\Facades\Log;
+
+class TasteQuery extends CriterionTool
+{
+    public function __construct(
+        private readonly QdrantService $qdrant,
+    ) {}
+
+    public function name(): string
+    {
+        return 'taste_query';
+    }
+
+    public function description(): string
+    {
+        return 'Search taste preferences and current vibe from Criterion and Lexi shared memory.';
+    }
+
+    public function execute(array $parameters): array
+    {
+        $query = $parameters['query'] ?? 'Jordan current mood and media preferences';
+        $limit = $parameters['limit'] ?? 5;
+
+        $criterionCollection = config('criterion.qdrant.collection');
+        $lexiCollection = config('criterion.qdrant.lexi_collection');
+
+        $taste = $this->searchSafe($criterionCollection, $query, $limit);
+        $vibe = $this->searchSafe($lexiCollection, $query, $limit);
+
+        return [
+            'taste' => $taste,
+            'vibe' => $vibe,
+            'summary' => $this->buildSummary($taste, $vibe),
+        ];
+    }
+
+    private function searchSafe(string $collection, string $query, int $limit): array
+    {
+        try {
+            return $this->qdrant->searchCollection($collection, $query, $limit);
+        } catch (\Throwable $e) {
+            Log::warning("TasteQuery: failed to search {$collection}", [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [];
+        }
+    }
+
+    private function buildSummary(array $taste, array $vibe): string
+    {
+        $parts = [];
+
+        if ($vibe !== []) {
+            $vibeSnippets = array_map(
+                fn (array $hit) => $hit['content'],
+                array_slice($vibe, 0, 3),
+            );
+            $parts[] = 'Lexi context: '.implode(' | ', $vibeSnippets);
+        }
+
+        if ($taste !== []) {
+            $tasteSnippets = array_map(
+                fn (array $hit) => $hit['content'],
+                array_slice($taste, 0, 3),
+            );
+            $parts[] = 'Taste memory: '.implode(' | ', $tasteSnippets);
+        }
+
+        return $parts !== [] ? implode("\n", $parts) : 'No shared memory available.';
+    }
+}

--- a/config/criterion.php
+++ b/config/criterion.php
@@ -8,6 +8,7 @@ return [
         'host' => env('QDRANT_HOST', 'localhost'),
         'port' => (int) env('QDRANT_PORT', 6333),
         'collection' => env('QDRANT_COLLECTION', 'criterion_memory'),
+        'lexi_collection' => env('QDRANT_LEXI_COLLECTION', 'lexi_memory'),
         'dimension' => (int) env('QDRANT_DIMENSION', 1536),
     ],
 

--- a/database/migrations/2025_01_01_000000_create_film_ratings_table.php
+++ b/database/migrations/2025_01_01_000000_create_film_ratings_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('film_ratings', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->unsignedSmallInteger('year')->nullable();
+            $table->unsignedInteger('tmdb_id')->nullable()->index();
+            $table->unsignedTinyInteger('rating');
+            $table->text('notes')->nullable();
+            $table->timestamp('watched_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('film_ratings');
+    }
+};

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,4 +17,10 @@
             <directory>./app</directory>
         </include>
     </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:dGVzdGluZ2tleWZvcnBocHVuaXQxMjM0NTY3OA=="/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+    </php>
 </phpunit>

--- a/tests/Unit/Agent/CriterionAgentTest.php
+++ b/tests/Unit/Agent/CriterionAgentTest.php
@@ -2,11 +2,18 @@
 
 use App\Agent\BaseAgent;
 use App\Agent\CriterionAgent;
+use App\Services\QdrantService;
 use App\Tools\MemorySearch;
 use App\Tools\MemoryStore;
+use App\Tools\RateFilm;
 use App\Tools\SlackReply;
+use App\Tools\TasteQuery;
 
 beforeEach(function () {
+    $this->qdrant = Mockery::mock(QdrantService::class);
+    $this->qdrant->shouldReceive('searchCollection')->andReturn([]);
+    $this->app->instance(QdrantService::class, $this->qdrant);
+
     $this->agent = app(CriterionAgent::class);
 });
 
@@ -20,6 +27,12 @@ it('has a mission prompt with the Criterion persona', function () {
         ->toContain('Princess Bride');
 });
 
+it('mentions shared Lexi memory in mission', function () {
+    $mission = $this->agent->mission();
+
+    expect($mission)->toContain('Lexi');
+});
+
 it('has domain context covering media services', function () {
     $context = $this->agent->domainContext();
 
@@ -30,15 +43,55 @@ it('has domain context covering media services', function () {
         ->toContain('Qdrant');
 });
 
-it('declares memory and slack tools', function () {
+it('includes shared memory reference in domain context', function () {
+    $context = $this->agent->domainContext();
+
+    expect($context)->toContain('Lexi');
+});
+
+it('declares memory, slack, taste, and rating tools', function () {
     $tools = $this->agent->domainTools();
 
     expect($tools)
         ->toContain(MemorySearch::class)
         ->toContain(MemoryStore::class)
-        ->toContain(SlackReply::class);
+        ->toContain(SlackReply::class)
+        ->toContain(TasteQuery::class)
+        ->toContain(RateFilm::class);
 });
 
 it('extends BaseAgent', function () {
     expect($this->agent)->toBeInstanceOf(BaseAgent::class);
+});
+
+it('injects vibe summary into domain context when memory available', function () {
+    $qdrant = Mockery::mock(QdrantService::class);
+    $qdrant->shouldReceive('searchCollection')
+        ->andReturn([
+            ['content' => 'Jordan feeling energized after morning run', 'score' => 0.9, 'metadata' => []],
+        ]);
+
+    $this->app->instance(QdrantService::class, $qdrant);
+    $this->app->forgetInstance(CriterionAgent::class);
+
+    $agent = app(CriterionAgent::class);
+    $context = $agent->domainContext();
+
+    expect($context)->toContain('Current vibe from shared memory');
+});
+
+it('handles vibe loading failure gracefully', function () {
+    $qdrant = Mockery::mock(QdrantService::class);
+    $qdrant->shouldReceive('searchCollection')
+        ->andThrow(new RuntimeException('Qdrant unreachable'));
+
+    $this->app->instance(QdrantService::class, $qdrant);
+    $this->app->forgetInstance(CriterionAgent::class);
+
+    $agent = app(CriterionAgent::class);
+    $context = $agent->domainContext();
+
+    expect($context)
+        ->toContain('Radarr')
+        ->not->toContain('Current vibe from shared memory');
 });

--- a/tests/Unit/Models/FilmRatingTest.php
+++ b/tests/Unit/Models/FilmRatingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\FilmRating;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+
+uses(RefreshDatabase::class);
+
+describe('FilmRating', function () {
+    it('can be created with valid attributes', function () {
+        $rating = FilmRating::create([
+            'title' => 'The Princess Bride',
+            'year' => 1987,
+            'tmdb_id' => 2493,
+            'rating' => 10,
+            'notes' => 'As you wish, sir.',
+            'watched_at' => now(),
+        ]);
+
+        expect($rating)->toBeInstanceOf(FilmRating::class);
+        expect($rating->id)->toBeInt();
+    });
+
+    it('casts year and rating as integers', function () {
+        $rating = FilmRating::create([
+            'title' => 'Inception',
+            'year' => 2010,
+            'rating' => 9,
+            'watched_at' => now(),
+        ]);
+
+        $rating->refresh();
+
+        expect($rating->year)->toBeInt();
+        expect($rating->rating)->toBeInt();
+    });
+
+    it('casts watched_at as datetime', function () {
+        $rating = FilmRating::create([
+            'title' => 'Interstellar',
+            'year' => 2014,
+            'rating' => 9,
+            'watched_at' => '2025-01-15 20:00:00',
+        ]);
+
+        $rating->refresh();
+
+        expect($rating->watched_at)->toBeInstanceOf(Carbon::class);
+    });
+
+    it('allows nullable fields', function () {
+        $rating = FilmRating::create([
+            'title' => 'Unknown Film',
+            'rating' => 5,
+        ]);
+
+        expect($rating->year)->toBeNull();
+        expect($rating->tmdb_id)->toBeNull();
+        expect($rating->notes)->toBeNull();
+        expect($rating->watched_at)->toBeNull();
+    });
+});

--- a/tests/Unit/Services/QdrantServiceTest.php
+++ b/tests/Unit/Services/QdrantServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+use App\Services\QdrantService;
+use Illuminate\Support\Facades\Http;
+
+describe('QdrantService::searchCollection', function () {
+    it('searches a specified collection', function () {
+        Http::fake([
+            '*/api/embeddings' => Http::response(['embedding' => array_fill(0, 1536, 0.1)]),
+            '*/collections/custom_collection/points/search' => Http::response([
+                'result' => [
+                    [
+                        'payload' => ['content' => 'test result'],
+                        'score' => 0.95,
+                    ],
+                ],
+            ]),
+        ]);
+
+        $service = app(QdrantService::class);
+        $results = $service->searchCollection('custom_collection', 'test query', 5);
+
+        expect($results)->toHaveCount(1);
+        expect($results[0]['content'])->toBe('test result');
+        expect($results[0]['score'])->toBe(0.95);
+    });
+
+    it('returns empty array when embedding fails', function () {
+        Http::fake([
+            '*/api/embeddings' => Http::response([], 500),
+        ]);
+
+        $service = app(QdrantService::class);
+        $results = $service->searchCollection('any_collection', 'test');
+
+        expect($results)->toBeEmpty();
+    });
+
+    it('returns empty array when search request fails', function () {
+        Http::fake([
+            '*/api/embeddings' => Http::response(['embedding' => array_fill(0, 1536, 0.1)]),
+            '*/collections/*/points/search' => Http::response([], 500),
+        ]);
+
+        $service = app(QdrantService::class);
+        $results = $service->searchCollection('broken_collection', 'test');
+
+        expect($results)->toBeEmpty();
+    });
+
+    it('delegates search to searchCollection with default collection', function () {
+        Http::fake([
+            '*/api/embeddings' => Http::response(['embedding' => array_fill(0, 1536, 0.1)]),
+            '*/collections/criterion_memory/points/search' => Http::response([
+                'result' => [
+                    [
+                        'payload' => ['content' => 'default collection hit'],
+                        'score' => 0.8,
+                    ],
+                ],
+            ]),
+        ]);
+
+        $service = app(QdrantService::class);
+        $results = $service->search('query');
+
+        expect($results)->toHaveCount(1);
+        expect($results[0]['content'])->toBe('default collection hit');
+    });
+
+    it('strips content from metadata in results', function () {
+        Http::fake([
+            '*/api/embeddings' => Http::response(['embedding' => array_fill(0, 1536, 0.1)]),
+            '*/collections/*/points/search' => Http::response([
+                'result' => [
+                    [
+                        'payload' => [
+                            'content' => 'the content',
+                            'type' => 'film_rating',
+                            'stored_at' => '2025-01-01T00:00:00Z',
+                        ],
+                        'score' => 0.9,
+                    ],
+                ],
+            ]),
+        ]);
+
+        $service = app(QdrantService::class);
+        $results = $service->searchCollection('test', 'query');
+
+        expect($results[0]['metadata'])->toHaveKey('type');
+        expect($results[0]['metadata'])->toHaveKey('stored_at');
+        expect($results[0]['metadata'])->not->toHaveKey('content');
+    });
+});

--- a/tests/Unit/Tools/RateFilmTest.php
+++ b/tests/Unit/Tools/RateFilmTest.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Models\FilmRating;
+use App\Services\QdrantService;
+use App\Tools\RateFilm;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+describe('RateFilm', function () {
+    beforeEach(function () {
+        $this->qdrant = Mockery::mock(QdrantService::class);
+        $this->tool = new RateFilm($this->qdrant);
+    });
+
+    it('stores a film rating in the database', function () {
+        $this->qdrant->shouldReceive('store')->once()->andReturn(true);
+
+        $result = $this->tool->execute([
+            'title' => 'Blade Runner 2049',
+            'year' => 2017,
+            'rating' => 9,
+            'notes' => 'Visually stunning sequel',
+        ]);
+
+        expect($result['stored'])->toBeTrue();
+        expect($result['title'])->toBe('Blade Runner 2049');
+        expect($result['rating'])->toBe(9);
+
+        $this->assertDatabaseHas('film_ratings', [
+            'title' => 'Blade Runner 2049',
+            'year' => 2017,
+            'rating' => 9,
+        ]);
+    });
+
+    it('stores the rating in Qdrant vector memory', function () {
+        $this->qdrant->shouldReceive('store')
+            ->once()
+            ->with(
+                Mockery::on(fn ($content) => str_contains($content, 'Blade Runner 2049') && str_contains($content, '9/10')),
+                Mockery::on(fn ($meta) => $meta['type'] === 'film_rating' && in_array('film', $meta['tags'])),
+            )
+            ->andReturn(true);
+
+        $this->tool->execute([
+            'title' => 'Blade Runner 2049',
+            'year' => 2017,
+            'rating' => 9,
+        ]);
+    });
+
+    it('returns error when title is missing', function () {
+        $this->qdrant->shouldNotReceive('store');
+
+        $result = $this->tool->execute(['rating' => 7]);
+
+        expect($result['stored'])->toBeFalse();
+        expect($result['error'])->toBeString();
+    });
+
+    it('returns error when rating is missing', function () {
+        $this->qdrant->shouldNotReceive('store');
+
+        $result = $this->tool->execute(['title' => 'Inception']);
+
+        expect($result['stored'])->toBeFalse();
+        expect($result['error'])->toBeString();
+    });
+
+    it('sets watched_at to current time', function () {
+        $this->qdrant->shouldReceive('store')->andReturn(true);
+
+        $this->tool->execute([
+            'title' => 'The Matrix',
+            'year' => 1999,
+            'rating' => 10,
+        ]);
+
+        $rating = FilmRating::first();
+        expect($rating->watched_at)->not->toBeNull();
+    });
+
+    it('stores optional tmdb_id', function () {
+        $this->qdrant->shouldReceive('store')->andReturn(true);
+
+        $this->tool->execute([
+            'title' => 'Dune',
+            'year' => 2021,
+            'rating' => 8,
+            'tmdb_id' => 438631,
+        ]);
+
+        $this->assertDatabaseHas('film_ratings', [
+            'title' => 'Dune',
+            'tmdb_id' => 438631,
+        ]);
+    });
+
+    it('has the correct tool name', function () {
+        expect($this->tool->name())->toBe('rate_film');
+    });
+
+    it('has a description mentioning rating and memory', function () {
+        expect($this->tool->description())
+            ->toContain('rating')
+            ->toContain('memory');
+    });
+});

--- a/tests/Unit/Tools/TasteQueryTest.php
+++ b/tests/Unit/Tools/TasteQueryTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Services\QdrantService;
+use App\Tools\TasteQuery;
+
+describe('TasteQuery', function () {
+    beforeEach(function () {
+        $this->qdrant = Mockery::mock(QdrantService::class);
+        $this->tool = new TasteQuery($this->qdrant);
+    });
+
+    it('returns taste and vibe arrays with a summary', function () {
+        $this->qdrant->shouldReceive('searchCollection')
+            ->with('criterion_memory', Mockery::type('string'), 5)
+            ->andReturn([
+                ['content' => 'Loves Blade Runner', 'score' => 0.95, 'metadata' => []],
+            ]);
+
+        $this->qdrant->shouldReceive('searchCollection')
+            ->with('lexi_memory', Mockery::type('string'), 5)
+            ->andReturn([
+                ['content' => 'Recovery score 85, mood: upbeat', 'score' => 0.88, 'metadata' => []],
+            ]);
+
+        $result = $this->tool->execute([]);
+
+        expect($result)
+            ->toHaveKey('taste')
+            ->toHaveKey('vibe')
+            ->toHaveKey('summary');
+
+        expect($result['taste'])->toHaveCount(1);
+        expect($result['vibe'])->toHaveCount(1);
+    });
+
+    it('builds summary from both collections', function () {
+        $this->qdrant->shouldReceive('searchCollection')
+            ->with('criterion_memory', Mockery::type('string'), 5)
+            ->andReturn([
+                ['content' => 'Rated Inception 9/10', 'score' => 0.9, 'metadata' => []],
+            ]);
+
+        $this->qdrant->shouldReceive('searchCollection')
+            ->with('lexi_memory', Mockery::type('string'), 5)
+            ->andReturn([
+                ['content' => 'HRV trending up, good recovery', 'score' => 0.85, 'metadata' => []],
+            ]);
+
+        $result = $this->tool->execute([]);
+
+        expect($result['summary'])
+            ->toContain('Lexi context')
+            ->toContain('Taste memory');
+    });
+
+    it('returns fallback summary when both collections are empty', function () {
+        $this->qdrant->shouldReceive('searchCollection')->andReturn([]);
+
+        $result = $this->tool->execute([]);
+
+        expect($result['summary'])->toBe('No shared memory available.');
+    });
+
+    it('handles lexi collection failure gracefully', function () {
+        $this->qdrant->shouldReceive('searchCollection')
+            ->with('criterion_memory', Mockery::type('string'), Mockery::type('int'))
+            ->andReturn([
+                ['content' => 'Likes thriller genre', 'score' => 0.8, 'metadata' => []],
+            ]);
+
+        $this->qdrant->shouldReceive('searchCollection')
+            ->with('lexi_memory', Mockery::type('string'), Mockery::type('int'))
+            ->andThrow(new RuntimeException('Connection refused'));
+
+        $result = $this->tool->execute([]);
+
+        expect($result['taste'])->toHaveCount(1);
+        expect($result['vibe'])->toBeEmpty();
+    });
+
+    it('accepts custom query and limit parameters', function () {
+        $this->qdrant->shouldReceive('searchCollection')
+            ->with('criterion_memory', 'sci-fi preferences', 3)
+            ->once()
+            ->andReturn([]);
+
+        $this->qdrant->shouldReceive('searchCollection')
+            ->with('lexi_memory', 'sci-fi preferences', 3)
+            ->once()
+            ->andReturn([]);
+
+        $this->tool->execute(['query' => 'sci-fi preferences', 'limit' => 3]);
+    });
+
+    it('has the correct tool name', function () {
+        expect($this->tool->name())->toBe('taste_query');
+    });
+
+    it('has a description mentioning taste and vibe', function () {
+        expect($this->tool->description())
+            ->toContain('taste')
+            ->toContain('vibe');
+    });
+});


### PR DESCRIPTION
## Summary

- **TasteQuery tool**: Semantic search across both Criterion taste memories AND Lexi health/mood memories in Qdrant, returning a unified vibe summary
- **RateFilm tool**: Logs film ratings to both the `film_ratings` database table and Qdrant vector memory with tags for taste learning
- **CriterionAgent**: Now injects current vibe context (mood, recovery, preferences) from shared Qdrant memory into the system prompt to inform recommendations
- **QdrantService**: Added `searchCollection()` for cross-collection queries (lexi_memory + criterion_memory)

## Shared Memory Architecture

```
Lexi Agent → writes mood/HRV/recovery → Qdrant (lexi_memory collection)
                                              ↓ reads
Criterion Agent ← TasteQuery ← searches both collections
Criterion Agent → RateFilm → writes ratings → Qdrant (criterion_memory) + SQLite (film_ratings)
```

## New Files

| File | Purpose |
|------|---------|
| `app/Tools/TasteQuery.php` | Searches both Qdrant collections, builds vibe summary |
| `app/Tools/RateFilm.php` | Persists film ratings to DB + vector memory |
| `app/Models/FilmRating.php` | Eloquent model for film_ratings table |
| `database/migrations/*_create_film_ratings_table.php` | Migration: title, year, tmdb_id, rating, notes, watched_at |
| `tests/Unit/Tools/TasteQueryTest.php` | 7 BDD tests (describe/it) |
| `tests/Unit/Tools/RateFilmTest.php` | 8 BDD tests with RefreshDatabase |
| `tests/Unit/Models/FilmRatingTest.php` | 4 BDD tests for model casts |
| `tests/Unit/Services/QdrantServiceTest.php` | 5 BDD tests with HTTP fakes |

## Test Plan

- [x] All 41 tests pass (88 assertions)
- [x] New tools: 100% coverage (TasteQuery, RateFilm, FilmRating)
- [x] Pint formatting clean
- [x] Mocked QdrantService — no live Qdrant required for tests
- [x] Graceful degradation when Qdrant unreachable

Closes #4