### PR TITLE
feat: watchdog with self-healing media services

### DIFF
--- a/app/Commands/WatchdogCommand.php
+++ b/app/Commands/WatchdogCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Commands;
+
+use App\Tools\ServiceHealth;
+use App\Tools\ServiceRestart;
+use App\Tools\SlackReply;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+
+class WatchdogCommand extends Command
+{
+    protected $signature = 'criterion:watchdog';
+
+    protected $description = 'Health-check all media services, self-heal with Podman restart, escalate to Slack on failure';
+
+    public function handle(ServiceHealth $health, ServiceRestart $restart, SlackReply $slack): int
+    {
+        $this->line('<fg=cyan>═══ Criterion Watchdog ═══</>');
+        $this->newLine();
+
+        $results = $health->run();
+        $failures = [];
+
+        foreach ($results as $name => $status) {
+            $label = ucfirst($name);
+
+            if ($status['healthy']) {
+                $this->line("  <fg=green>✓</> {$label}");
+
+                continue;
+            }
+
+            $this->line("  <fg=red>✗</> {$label} — attempting restart…");
+
+            $restartResult = $restart->run([
+                'container' => $status['container'],
+                'wait' => 10,
+            ]);
+
+            if ($restartResult['recovered']) {
+                Log::info("{$label} has been restored after restart");
+                $this->line("  <fg=yellow>↻</> {$label} — restored");
+            } else {
+                $failures[] = $name;
+                $this->line("  <fg=red>✗</> {$label} — still down after restart");
+            }
+        }
+
+        if ($failures !== []) {
+            $this->escalate($slack, $failures);
+        }
+
+        $this->newLine();
+        $this->line(count($failures) === 0
+            ? '<fg=green>All services operational.</>'
+            : '<fg=red>'.count($failures).' service(s) require attention.</>');
+
+        return count($failures) === 0 ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function escalate(SlackReply $slack, array $failures): void
+    {
+        foreach ($failures as $name) {
+            $label = ucfirst($name);
+            $message = "{$label} is unresponsive, sir. I was unable to revive it.";
+
+            $slack->run(['message' => $message]);
+
+            Log::critical("Watchdog escalation: {$name} is unresponsive after restart attempt");
+        }
+    }
+}

--- a/app/Tools/ServiceHealth.php
+++ b/app/Tools/ServiceHealth.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Tools;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+class ServiceHealth extends CriterionTool
+{
+    public function name(): string
+    {
+        return 'service_health';
+    }
+
+    public function description(): string
+    {
+        return 'Check health of all monitored media services.';
+    }
+
+    public function execute(array $parameters): array
+    {
+        $services = $this->services();
+        $results = [];
+
+        foreach ($services as $name => $config) {
+            $results[$name] = $this->check($name, $config);
+        }
+
+        return $results;
+    }
+
+    public function services(): array
+    {
+        return [
+            'radarr' => [
+                'url' => config('services.radarr.url').'/api/v3/health',
+                'headers' => ['X-Api-Key' => config('services.radarr.api_key')],
+                'container' => 'radarr',
+            ],
+            'sonarr' => [
+                'url' => config('services.sonarr.url').'/api/v3/health',
+                'headers' => ['X-Api-Key' => config('services.sonarr.api_key')],
+                'container' => 'sonarr',
+            ],
+            'jellyfin' => [
+                'url' => config('services.jellyfin.url').'/health',
+                'headers' => [],
+                'container' => 'jellyfin',
+            ],
+            'prowlarr' => [
+                'url' => config('services.prowlarr.url').'/api/v1/health',
+                'headers' => ['X-Api-Key' => config('services.prowlarr.api_key')],
+                'container' => 'prowlarr',
+            ],
+            'transmission' => [
+                'url' => config('services.transmission.url').'/transmission/rpc',
+                'headers' => [],
+                'container' => 'transmission',
+            ],
+        ];
+    }
+
+    private function check(string $name, array $config): array
+    {
+        try {
+            $response = Http::timeout(5)
+                ->withHeaders($config['headers'])
+                ->get($config['url']);
+
+            $healthy = $response->successful() || $response->status() === 409;
+
+            return [
+                'healthy' => $healthy,
+                'status' => $response->status(),
+                'container' => $config['container'],
+            ];
+        } catch (\Throwable $e) {
+            Log::warning("Health check failed for {$name}", [
+                'error' => $e->getMessage(),
+            ]);
+
+            return [
+                'healthy' => false,
+                'status' => 0,
+                'container' => $config['container'],
+            ];
+        }
+    }
+}

--- a/app/Tools/ServiceRestart.php
+++ b/app/Tools/ServiceRestart.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Tools;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
+
+class ServiceRestart extends CriterionTool
+{
+    public function name(): string
+    {
+        return 'service_restart';
+    }
+
+    public function description(): string
+    {
+        return 'Restart a media service container via Podman and verify recovery.';
+    }
+
+    public function execute(array $parameters): array
+    {
+        $container = $parameters['container'] ?? '';
+
+        if ($container === '') {
+            return ['restarted' => false, 'recovered' => false, 'error' => 'No container specified'];
+        }
+
+        $allowed = ['radarr', 'sonarr', 'jellyfin', 'prowlarr', 'transmission'];
+
+        if (! in_array($container, $allowed, true)) {
+            return ['restarted' => false, 'recovered' => false, 'error' => 'Invalid container name'];
+        }
+
+        Log::info("Attempting podman restart for {$container}");
+
+        $result = Process::timeout(30)->run("podman restart {$container}");
+
+        if (! $result->successful()) {
+            Log::error("Podman restart failed for {$container}", [
+                'output' => $result->errorOutput(),
+            ]);
+
+            return ['restarted' => false, 'recovered' => false, 'error' => $result->errorOutput()];
+        }
+
+        sleep($parameters['wait'] ?? 10);
+
+        $health = app(ServiceHealth::class);
+        $services = $health->services();
+        $serviceConfig = $services[$container] ?? null;
+
+        if (! $serviceConfig) {
+            return ['restarted' => true, 'recovered' => false, 'error' => 'No health config for container'];
+        }
+
+        $recheck = $health->run(['service' => $container]);
+        $recovered = ($recheck[$container]['healthy'] ?? false);
+
+        Log::info("Restart result for {$container}", ['recovered' => $recovered]);
+
+        return ['restarted' => true, 'recovered' => $recovered];
+    }
+}

--- a/config/services.php
+++ b/config/services.php
@@ -13,6 +13,13 @@ return [
         'url' => env('JELLYFIN_URL', 'http://100.68.122.24:8096'),
         'api_key' => env('JELLYFIN_API_KEY'),
     ],
+    'prowlarr' => [
+        'url' => env('PROWLARR_URL', 'http://100.68.211.1:9696'),
+        'api_key' => env('PROWLARR_API_KEY'),
+    ],
+    'transmission' => [
+        'url' => env('TRANSMISSION_URL', 'http://100.68.122.24:9091'),
+    ],
     'ollama' => [
         'url' => env('OLLAMA_URL', 'http://100.68.122.24:11434'),
         'model' => env('OLLAMA_MODEL', 'llama3.2:3b'),

--- a/routes/console.php
+++ b/routes/console.php
@@ -2,10 +2,6 @@
 
 use Illuminate\Support\Facades\Artisan;
 
-Artisan::command('criterion:watchdog', function () {
-    $this->info('Criterion watchdog — checking library health...');
-})->purpose('Periodic library health check');
-
 Artisan::command('criterion:audit', function () {
     $this->info('Criterion weekly audit — analyzing library trends...');
 })->purpose('Weekly library audit and recommendations');

--- a/tests/Feature/WatchdogCommandTest.php
+++ b/tests/Feature/WatchdogCommandTest.php
@@ -1,0 +1,160 @@
+<?php
+
+use App\Tools\ServiceHealth;
+use App\Tools\ServiceRestart;
+use App\Tools\SlackReply;
+use Illuminate\Support\Facades\Http;
+
+describe('criterion:watchdog', function () {
+    it('reports success when all services are healthy', function () {
+        Http::fake([
+            '*/api/v3/health' => Http::response([], 200),
+            '*/health' => Http::response('Healthy', 200),
+            '*/transmission/rpc' => Http::response('', 409),
+            '*/api/v1/health' => Http::response([], 200),
+        ]);
+
+        $this->artisan('criterion:watchdog')
+            ->assertExitCode(0);
+    });
+
+    it('does not attempt restart when all services are healthy', function () {
+        Http::fake([
+            '*/api/v3/health' => Http::response([], 200),
+            '*/health' => Http::response('Healthy', 200),
+            '*/transmission/rpc' => Http::response('', 409),
+            '*/api/v1/health' => Http::response([], 200),
+        ]);
+
+        $this->mock(ServiceRestart::class, function ($mock) {
+            $mock->shouldNotReceive('run');
+        });
+
+        $this->artisan('criterion:watchdog')
+            ->assertExitCode(0);
+    });
+
+    it('escalates to Slack when restart fails to recover a service', function () {
+        $this->mock(ServiceHealth::class, function ($mock) {
+            $mock->shouldReceive('run')
+                ->once()
+                ->andReturn([
+                    'radarr' => ['healthy' => false, 'status' => 500, 'container' => 'radarr'],
+                    'sonarr' => ['healthy' => true, 'status' => 200, 'container' => 'sonarr'],
+                    'jellyfin' => ['healthy' => true, 'status' => 200, 'container' => 'jellyfin'],
+                    'prowlarr' => ['healthy' => true, 'status' => 200, 'container' => 'prowlarr'],
+                    'transmission' => ['healthy' => true, 'status' => 409, 'container' => 'transmission'],
+                ]);
+        });
+
+        $this->mock(ServiceRestart::class, function ($mock) {
+            $mock->shouldReceive('run')
+                ->once()
+                ->with(Mockery::on(fn ($params) => $params['container'] === 'radarr'))
+                ->andReturn(['restarted' => true, 'recovered' => false]);
+        });
+
+        $this->mock(SlackReply::class, function ($mock) {
+            $mock->shouldReceive('run')
+                ->once()
+                ->with(Mockery::on(fn ($params) => str_contains($params['message'], 'Radarr is unresponsive, sir')))
+                ->andReturn(true);
+        });
+
+        $this->artisan('criterion:watchdog')
+            ->assertExitCode(1);
+    });
+
+    it('uses Criterion voice in escalation messages', function () {
+        $this->mock(ServiceHealth::class, function ($mock) {
+            $mock->shouldReceive('run')
+                ->once()
+                ->andReturn([
+                    'radarr' => ['healthy' => false, 'status' => 0, 'container' => 'radarr'],
+                    'sonarr' => ['healthy' => false, 'status' => 0, 'container' => 'sonarr'],
+                    'jellyfin' => ['healthy' => true, 'status' => 200, 'container' => 'jellyfin'],
+                    'prowlarr' => ['healthy' => true, 'status' => 200, 'container' => 'prowlarr'],
+                    'transmission' => ['healthy' => true, 'status' => 409, 'container' => 'transmission'],
+                ]);
+        });
+
+        $this->mock(ServiceRestart::class, function ($mock) {
+            $mock->shouldReceive('run')
+                ->twice()
+                ->andReturn(['restarted' => true, 'recovered' => false]);
+        });
+
+        $messages = [];
+        $this->mock(SlackReply::class, function ($mock) use (&$messages) {
+            $mock->shouldReceive('run')
+                ->twice()
+                ->andReturnUsing(function ($params) use (&$messages) {
+                    $messages[] = $params['message'];
+
+                    return true;
+                });
+        });
+
+        $this->artisan('criterion:watchdog')
+            ->assertExitCode(1);
+
+        expect($messages[0])->toContain('Radarr is unresponsive, sir. I was unable to revive it.');
+        expect($messages[1])->toContain('Sonarr is unresponsive, sir. I was unable to revive it.');
+    });
+
+    it('does not escalate when a service recovers after restart', function () {
+        $this->mock(ServiceHealth::class, function ($mock) {
+            $mock->shouldReceive('run')
+                ->once()
+                ->andReturn([
+                    'radarr' => ['healthy' => false, 'status' => 500, 'container' => 'radarr'],
+                    'sonarr' => ['healthy' => true, 'status' => 200, 'container' => 'sonarr'],
+                    'jellyfin' => ['healthy' => true, 'status' => 200, 'container' => 'jellyfin'],
+                    'prowlarr' => ['healthy' => true, 'status' => 200, 'container' => 'prowlarr'],
+                    'transmission' => ['healthy' => true, 'status' => 409, 'container' => 'transmission'],
+                ]);
+        });
+
+        $this->mock(ServiceRestart::class, function ($mock) {
+            $mock->shouldReceive('run')
+                ->once()
+                ->andReturn(['restarted' => true, 'recovered' => true]);
+        });
+
+        $this->mock(SlackReply::class, function ($mock) {
+            $mock->shouldNotReceive('run');
+        });
+
+        $this->artisan('criterion:watchdog')
+            ->assertExitCode(0);
+    });
+
+    it('returns failure exit code when any service remains down', function () {
+        $this->mock(ServiceHealth::class, function ($mock) {
+            $mock->shouldReceive('run')
+                ->once()
+                ->andReturn([
+                    'radarr' => ['healthy' => false, 'status' => 0, 'container' => 'radarr'],
+                    'sonarr' => ['healthy' => true, 'status' => 200, 'container' => 'sonarr'],
+                    'jellyfin' => ['healthy' => true, 'status' => 200, 'container' => 'jellyfin'],
+                    'prowlarr' => ['healthy' => true, 'status' => 200, 'container' => 'prowlarr'],
+                    'transmission' => ['healthy' => true, 'status' => 409, 'container' => 'transmission'],
+                ]);
+        });
+
+        $this->mock(ServiceRestart::class, function ($mock) {
+            $mock->shouldReceive('run')
+                ->once()
+                ->andReturn(['restarted' => true, 'recovered' => false]);
+        });
+
+        $this->mock(SlackReply::class, function ($mock) {
+            $mock->shouldReceive('run')
+                ->once()
+                ->andReturn(true);
+        });
+
+        $this->artisan('criterion:watchdog')
+            ->assertExitCode(1);
+    });
+});

--- a/tests/Unit/Tools/ServiceHealthTest.php
+++ b/tests/Unit/Tools/ServiceHealthTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Tools\ServiceHealth;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+
+describe('ServiceHealth', function () {
+    beforeEach(function () {
+        $this->tool = app(ServiceHealth::class);
+    });
+
+    it('has the correct tool name', function () {
+        expect($this->tool->name())->toBe('service_health');
+    });
+
+    it('has a description', function () {
+        expect($this->tool->description())->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns healthy status for reachable services', function () {
+        Http::fake([
+            '*/api/v3/health' => Http::response([], 200),
+            '*/health' => Http::response('Healthy', 200),
+            '*/api/v1/health' => Http::response([], 200),
+            '*/transmission/rpc' => Http::response('', 409),
+        ]);
+
+        $results = $this->tool->execute([]);
+
+        expect($results)
+            ->toHaveKeys(['radarr', 'sonarr', 'jellyfin', 'prowlarr', 'transmission']);
+
+        foreach ($results as $service) {
+            expect($service['healthy'])->toBeTrue();
+        }
+    });
+
+    it('returns unhealthy status for unreachable services', function () {
+        Http::fake([
+            '*' => Http::response('Server Error', 500),
+        ]);
+
+        $results = $this->tool->execute([]);
+
+        foreach ($results as $service) {
+            expect($service['healthy'])->toBeFalse();
+        }
+    });
+
+    it('handles connection timeouts gracefully', function () {
+        Http::fake([
+            '*' => fn () => throw new ConnectionException('Connection timed out'),
+        ]);
+
+        $results = $this->tool->execute([]);
+
+        foreach ($results as $service) {
+            expect($service['healthy'])->toBeFalse();
+            expect($service['status'])->toBe(0);
+        }
+    });
+
+    it('treats HTTP 409 as healthy for Transmission RPC', function () {
+        Http::fake([
+            '*/api/v3/health' => Http::response([], 200),
+            '*/health' => Http::response('Healthy', 200),
+            '*/api/v1/health' => Http::response([], 200),
+            '*/transmission/rpc' => Http::response('', 409),
+        ]);
+
+        $results = $this->tool->execute([]);
+
+        expect($results['transmission']['healthy'])->toBeTrue();
+    });
+
+    it('includes container name in each result', function () {
+        Http::fake(['*' => Http::response([], 200)]);
+
+        $results = $this->tool->execute([]);
+
+        expect($results['radarr']['container'])->toBe('radarr');
+        expect($results['sonarr']['container'])->toBe('sonarr');
+        expect($results['jellyfin']['container'])->toBe('jellyfin');
+        expect($results['prowlarr']['container'])->toBe('prowlarr');
+        expect($results['transmission']['container'])->toBe('transmission');
+    });
+
+    it('defines all five monitored services', function () {
+        $services = $this->tool->services();
+
+        expect($services)->toHaveCount(5)
+            ->toHaveKeys(['radarr', 'sonarr', 'jellyfin', 'prowlarr', 'transmission']);
+    });
+});

--- a/tests/Unit/Tools/ServiceRestartTest.php
+++ b/tests/Unit/Tools/ServiceRestartTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Tools\ServiceHealth;
+use App\Tools\ServiceRestart;
+use Illuminate\Support\Facades\Process;
+
+describe('ServiceRestart', function () {
+    beforeEach(function () {
+        $this->tool = app(ServiceRestart::class);
+    });
+
+    it('has the correct tool name', function () {
+        expect($this->tool->name())->toBe('service_restart');
+    });
+
+    it('has a description', function () {
+        expect($this->tool->description())->toBeString()->not->toBeEmpty();
+    });
+
+    it('rejects empty container name', function () {
+        $result = $this->tool->execute([]);
+
+        expect($result['restarted'])->toBeFalse();
+        expect($result['error'])->toBe('No container specified');
+    });
+
+    it('rejects invalid container names', function () {
+        $result = $this->tool->execute(['container' => 'malicious-container']);
+
+        expect($result['restarted'])->toBeFalse();
+        expect($result['error'])->toBe('Invalid container name');
+    });
+
+    it('accepts all five valid container names', function () {
+        $valid = ['radarr', 'sonarr', 'jellyfin', 'prowlarr', 'transmission'];
+
+        foreach ($valid as $container) {
+            Process::fake([
+                "podman restart {$container}" => Process::result(output: $container),
+            ]);
+
+            $mock = Mockery::mock(ServiceHealth::class);
+            $mock->shouldReceive('services')->andReturn([
+                $container => [
+                    'url' => "http://localhost/{$container}",
+                    'headers' => [],
+                    'container' => $container,
+                ],
+            ]);
+            $mock->shouldReceive('run')->andReturn([
+                $container => ['healthy' => true, 'status' => 200, 'container' => $container],
+            ]);
+
+            $this->app->instance(ServiceHealth::class, $mock);
+
+            $result = $this->tool->execute(['container' => $container, 'wait' => 0]);
+
+            expect($result['restarted'])->toBeTrue();
+        }
+    });
+
+    it('reports failure when podman restart fails', function () {
+        Process::fake([
+            'podman restart radarr' => Process::result(exitCode: 1, errorOutput: 'no such container'),
+        ]);
+
+        $result = $this->tool->execute(['container' => 'radarr', 'wait' => 0]);
+
+        expect($result['restarted'])->toBeFalse();
+        expect($result['recovered'])->toBeFalse();
+        expect($result['error'])->toContain('no such container');
+    });
+
+    it('reports recovered true when service comes back after restart', function () {
+        Process::fake([
+            '*' => Process::result(output: 'radarr'),
+        ]);
+
+        $mock = Mockery::mock(ServiceHealth::class);
+        $mock->shouldReceive('services')->andReturn([
+            'radarr' => [
+                'url' => 'http://localhost/api/v3/health',
+                'headers' => [],
+                'container' => 'radarr',
+            ],
+        ]);
+        $mock->shouldReceive('run')->andReturn([
+            'radarr' => ['healthy' => true, 'status' => 200, 'container' => 'radarr'],
+        ]);
+
+        $this->app->instance(ServiceHealth::class, $mock);
+
+        $result = $this->tool->execute(['container' => 'radarr', 'wait' => 0]);
+
+        expect($result['restarted'])->toBeTrue();
+        expect($result['recovered'])->toBeTrue();
+    });
+
+    it('reports recovered false when service stays down after restart', function () {
+        Process::fake([
+            '*' => Process::result(output: 'radarr'),
+        ]);
+
+        $mock = Mockery::mock(ServiceHealth::class);
+        $mock->shouldReceive('services')->andReturn([
+            'radarr' => [
+                'url' => 'http://localhost/api/v3/health',
+                'headers' => [],
+                'container' => 'radarr',
+            ],
+        ]);
+        $mock->shouldReceive('run')->andReturn([
+            'radarr' => ['healthy' => false, 'status' => 500, 'container' => 'radarr'],
+        ]);
+
+        $this->app->instance(ServiceHealth::class, $mock);
+
+        $result = $this->tool->execute(['container' => 'radarr', 'wait' => 0]);
+
+        expect($result['restarted'])->toBeTrue();
+        expect($result['recovered'])->toBeFalse();
+    });
+});


### PR DESCRIPTION
## Summary

- **ServiceHealth** tool checks all 5 media services (Radarr, Sonarr, Jellyfin, Prowlarr, Transmission) via their health endpoints
- **ServiceRestart** tool runs `podman restart` with a strict container allowlist, then rechecks health after 10s
- **WatchdogCommand** (`criterion:watchdog`) orchestrates the full flow: health check → self-heal → Slack escalation
- Scheduled every 5 minutes via `bootstrap/app.php` (already wired)
- Criterion voice for escalation: *"Radarr is unresponsive, sir. I was unable to revive it."*
- Silent logging on successful recovery — no Slack noise

## Self-heal flow

```
for each service:
  ping health endpoint
  if down:
    podman restart {container}
    sleep 10s
    recheck
    if still down → Slack escalation
    if recovered → log silently
```

## Files changed

| File | Purpose |
|------|---------|
| `app/Tools/ServiceHealth.php` | Health checks for all 5 services |
| `app/Tools/ServiceRestart.php` | Podman restart with recovery verification |
| `app/Commands/WatchdogCommand.php` | Orchestrator command |
| `config/services.php` | Added Prowlarr + Transmission configs |
| `routes/console.php` | Removed placeholder stub |
| `tests/Feature/WatchdogCommandTest.php` | 6 BDD tests for command |
| `tests/Unit/Tools/ServiceHealthTest.php` | 8 BDD tests for health tool |
| `tests/Unit/Tools/ServiceRestartTest.php` | 8 BDD tests for restart tool |

## Test plan

- [x] All 35 Pest tests pass (22 new + 13 existing)
- [x] Pint passes with no changes
- [ ] Coverage requires PCOV/Xdebug (not available in CI yet)
- [ ] Manual test on Odin with live services

Closes #3